### PR TITLE
Limit paho-mqtt version to <2.0.0 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ udsoncan>=1.21.2
 doipclient
 python-can
 can-isotp>=2.0.2
-paho-mqtt
+paho-mqtt<2.0.0


### PR DESCRIPTION
Paho-mqtt is available at version 2.0.0 but gives error.
```
$ python3 Open3Eclient.py @pt2_mqtt
Traceback (most recent call last):
  File "/home/e3/open3e/Open3Eclient.py", line 330, in <module>
    mqtt_client = paho.Client("Open3E" + '_' + str(int(time.time()*1000)))  # Unique mqtt id using timestamp
  File "/home/e3/.local/lib/python3.9/site-packages/paho/mqtt/client.py", line 766, in __init__
    raise ValueError(
ValueError: Unsupported callback API version: version 2.0 added a callback_api_version, see migrations.md for details
```

Limit paho-mqtt to <2.0.0.
