### PR TITLE
Develop merge to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ For more detailed description of the command line arguments see also the [accord
     -l, --listen            mqtt topic to listen for commands, e.g. `open3e/cmnd`
     @argsfile               use arguments given in a file. Seperate line for each argument. No linebreak after final entry. 
 
-(*) **Attention!:** The option `-dev DEV, --dev DEV` is deprecated and may be removed in future versions. Make use of `-cnfg DEVICES.JSON` instead!
+(*) **Attention!** The option `-dev DEV, --dev DEV` is deprecated and may be removed in future versions. Make use of `-cnfg DEVICES.JSON` instead! You may also use `-cnfg dev` which is equal to `-cnfg devices.json` 
+
+<br>
 
 **_regarding the following examples: Please be aware of that not all datapoints exist with every device._**
 
@@ -95,24 +97,24 @@ For more detailed description of the command line arguments see also the [accord
     open3e -c can0 -cnfg devices.json -r 268 -v
     268 FlowTempSensor 27.2
 
-    open3e -c can0 -cnfg devices.json -r 318 -v
+    open3e -c can0 -cnfg dev -r 318 -v
     318 WaterPressureSensor 1.8 
 
-    open3e -c can0 -cnfg devices.json -r 377 -v
+    open3e -c can0 -cnfg dev -r 377 -v
     377 IdentNumber 7XXXXXXXXXXXXX 
 
-    open3e -c can0 -cnfg devices.json -r 1043 -v
+    open3e -c can0 -cnfg dev -r 1043 -v
     1043 FlowMeterSensor 2412.0 
 
-    open3e -c can0 -cnfg devices.json -r 1664 -v
+    open3e -c can0 -cnfg dev -r 1664 -v
     1664 ElectricalEnergyStorageStateOfCharge 44 
 
     open3e @myargs
         with content of file myargs:
         -c
         can0
-        -dev
-        vx3
+        -cnfg
+        devices.jsom
         -r
         1664
         -v
@@ -135,7 +137,7 @@ For more detailed description of the command line arguments see also the [accord
     open3e -c can0 -cnfg devices.json -w 396='47.5'
     -> sets domestic hot water setpoint to 47.5degC
 
-    open3e -c can0 -cnfg devices.json -w 538='{"Mode": 1, "State": 0}'
+    open3e -c can0 -cnfg dev -w 538='{"Mode": 1, "State": 0}'
     -> sets ExternalDomesticHotWaterTargetOperationMode.Mode to 1 and .State to 0
     -> Use -j -r to read data point in json format as template for writing. Always provide valid and complete json data for writing, enclosed in single quotes.
  
@@ -147,7 +149,7 @@ In case of a "negative response" code when writing data, you may try to use the 
     open3e -c can0 -cnfg devices.json -r 268,269,271,274,318,1043 -m 192.168.0.5:1883:open3e -t 1
     -> will periodically scan data points and publish data to broker 192.168.0.5 
 
-    open3e -c can0 -cnfg devices.json -r 268,269,271,274,318,1043 -m 192.168.0.5:1883:open3e -t 1 -mfstr "{didNumber}_{didName}"
+    open3e -c can0 -cnfg dev -r 268,269,271,274,318,1043 -m 192.168.0.5:1883:open3e -t 1 -mfstr "{didNumber}_{didName}"
     -> will publish with custom identifier format: e.g. open3e/268_FlowTemperatureSensor 
 
 # Listener mode

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open3E interface
 
-* Connects E3 boiler (vcal or vdens) controller through CAN UDS or doip
+* Connects E3 'OneBase' device through CAN UDS or doip
 * Read known data points
 * Listen to commands on mqtt
 * Write data points in raw and json data format
@@ -25,7 +25,7 @@ or for the develop branch
 
 This will install open3e along with all dependencies.
 
-If you get the error "error: externally-managed-environment" you could add *--break-system-packages* to the preveious command.<br>
+If you get the error "error: externally-managed-environment" you could add *--break-system-packages* to the previous command, but better install using a virtual environment - venv<br>
 (please see: https://stackoverflow.com/questions/75608323/how-do-i-solve-error-externally-managed-environment-every-time-i-use-pip-3)  
 
 # Setup CAN Bus
@@ -61,7 +61,7 @@ For more detailed description of the command line arguments see also the [accord
     -h, --help              show this help message and exit
     -c CAN, --can CAN       use can device, e.g. can0
     -d DOIP, --doip DOIP    use doip access, e.g. 192.168.1.1
-    -dev DEV, --dev DEV     boiler type --dev vdens or --dev vcal || pv/battery --dev vx3, --dev vair
+    (*)-dev DEV, --dev DEV     boiler type --dev vdens or --dev vcal || pv/battery --dev vx3, --dev vair(*)
     -a, --scanall           dump all dids
     -r READ, --read READ    read did, e.g. 0x173,0x174
     -raw, --raw             return raw data for all dids
@@ -84,23 +84,28 @@ For more detailed description of the command line arguments see also the [accord
     -j, --json              send JSON structure via MQTT
     -v, --verbose           verbose info
     -l, --listen            mqtt topic to listen for commands, e.g. `open3e/cmnd`
-    @argsfile               use arguments given in a file. Seperate line for each argument.
+    @argsfile               use arguments given in a file. Seperate line for each argument. No linebreak after final entry. 
+
+(*) **Attention!:** The option `-dev DEV, --dev DEV` is deprecated and may be removed in future versions. Make use of `-cnfg DEVICES.JSON` instead!
+
+**_regarding the following examples: Please be aware of that not all datapoints exist with every device._**
 
 # Read dids
-    open3e -c can0 -dev vdens -r 268 -v
+
+    open3e -c can0 -cnfg devices.json -r 268 -v
     268 FlowTempSensor 27.2
 
-    open3e -c can0 -dev vcal -r 318 -v
-    318 WaterPressureSensor 1.8
+    open3e -c can0 -cnfg devices.json -r 318 -v
+    318 WaterPressureSensor 1.8 
 
-    open3e -c can0 -dev vcal -r 377 -v
-    377 IdentNumber 7XXXXXXXXXXXXX
+    open3e -c can0 -cnfg devices.json -r 377 -v
+    377 IdentNumber 7XXXXXXXXXXXXX 
 
-    open3e -c can0 -dev vcal -r 1043 -v
-    1043 FlowMeterSensor 2412.0
+    open3e -c can0 -cnfg devices.json -r 1043 -v
+    1043 FlowMeterSensor 2412.0 
 
-    open3e -c can0 -dev vx3 -r 1664 -v
-    1664 ElectricalEnergyStorageStateOfCharge 44
+    open3e -c can0 -cnfg devices.json -r 1664 -v
+    1664 ElectricalEnergyStorageStateOfCharge 44 
 
     open3e @myargs
         with content of file myargs:
@@ -113,38 +118,40 @@ For more detailed description of the command line arguments see also the [accord
         -v
 
 # Interval Readout
-    open3e -c can0 -dev vcal -r 1043 -t 1
+    open3e -c can0 -cnfg devices.json -r 1043 -t 1
     2412.0
     2413.0
     2411.0
     2412.0
     ...
+  
 
 # Write did
 ## Using raw data format
-    open3e -c can0 -dev vdens -raw -w 396=D601
+    open3e -c can0 -cnfg devices.json -raw -w 396=D601
     -> sets domestic hot water setpoint to 47degC
 
 ## Using json data format
-    open3e -c can0 -dev vdens -w 396='47.5'
+    open3e -c can0 -cnfg devices.json -w 396='47.5'
     -> sets domestic hot water setpoint to 47.5degC
 
-    open3e -c can0 -dev vdens -w 538='{"Mode": 1, "State": 0}'
+    open3e -c can0 -cnfg devices.json -w 538='{"Mode": 1, "State": 0}'
     -> sets ExternalDomesticHotWaterTargetOperationMode.Mode to 1 and .State to 0
     -> Use -j -r to read data point in json format as template for writing. Always provide valid and complete json data for writing, enclosed in single quotes.
+ 
 
 ## Extended writing service (internal can bus only, experimental)
-    In case of a "negative response" code when writing data, you may try to use the command line option -f77. However, this is experimental. Always verify the result!
+In case of a "negative response" code when writing data, you may try to use the command line option -f77. However, this is experimental. Always verify the result!
 
 # Publish data points to mqtt
-    open3e -c can0 -dev vcal -r 268,269,271,274,318,1043 -m 192.168.0.5:1883:open3e -t 1
-    -> will periodically scan data points and publish data to broker 192.168.0.5
+    open3e -c can0 -cnfg devices.json -r 268,269,271,274,318,1043 -m 192.168.0.5:1883:open3e -t 1
+    -> will periodically scan data points and publish data to broker 192.168.0.5 
 
-    open3e -c can0 -dev vcal -r 268,269,271,274,318,1043 -m 192.168.0.5:1883:open3e -t 1 -mfstr "{didNumber}_{didName}"
-    -> will publish with custom identifier format: e.g. open3e/268_FlowTemperatureSensor
+    open3e -c can0 -cnfg devices.json -r 268,269,271,274,318,1043 -m 192.168.0.5:1883:open3e -t 1 -mfstr "{didNumber}_{didName}"
+    -> will publish with custom identifier format: e.g. open3e/268_FlowTemperatureSensor 
 
 # Listener mode
-    open3e -c can0 -dev vcal -m 192.168.0.5:1883:open3e -mfstr "{didNumber}_{didName}" -l open3e/cmnd
+    open3e -c can0 -cnfg devices.json -m 192.168.0.5:1883:open3e -mfstr "{didNumber}_{didName}" -l open3e/cmnd
     
     will listen for commands on topic open3e/cmnd with payload in json format:
     {"mode":"read"|"read-raw"|"read-pure"|"read-all"|"write"|"write-raw", "data":[list of data], "addr":"ECU_addr"}
@@ -195,5 +202,5 @@ If you want to work on the codebase you can clone the repository and work in "ed
     cd open3e
     pip install --editable .[dev]
 
-Hint: If you get an error like "A "pyproject.toml" file was found, but editable mode currently requires a setup.py based build." you are running an old pip version. Editable mode requires pip version >= 21.1.
-=======
+**Hint: If you get an error like "A "pyproject.toml" file was found, but editable mode currently requires a setup.py based build." you are running an old pip version. Editable mode requires pip version >= 21.1.**
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ namespaces = true
 # PEP 621 https://peps.python.org/pep-0621/
 [project]
 name = "open3e"
-version = "0.3.7"
+version = "0.3.8"
 # for automated versioning by pypa/setuptools_scm. see https://peps.python.org/pep-0621/#dynamic
 # dynamic = ["version"]
 description = "Connects to E3 (vcal, vdens, vx3...) controllers through CAN UDS or DOIP."

--- a/src/open3e/Open3Edatapoints.json
+++ b/src/open3e/Open3Edatapoints.json
@@ -31744,43 +31744,159 @@
     }
   },
   "2622": {
-    "codec": "O3EInt16",
+    "codec": "O3EComplexType",
     "len": 9,
-    "id": "SeasonalCoefficientOfPerformaceHeating",
+    "id": "SeasonalCoefficientOfPerformanceHeating",
     "args": {
-      "scale": 10.0,
-      "signed": false,
-      "offset": 0
+      "subTypes": [
+        {
+          "codec": "O3EInt8",
+          "len": 1,
+          "id": "CurrentYear",
+          "args": {
+            "scale": 10,
+            "signed": false,
+            "offset": 0
+          }
+        },
+        {
+          "codec": "O3EInt32",
+          "len": 4,
+          "id": "EnergyThermal",
+          "args": {
+            "scale": 10,
+            "signed": false,
+            "offset": 0
+          }
+        },
+        {
+          "codec": "O3EInt32",
+          "len": 4,
+          "id": "EnergyElectric",
+          "args": {
+            "scale": 10,
+            "signed": false,
+            "offset": 0
+          }
+        }
+      ]
     }
   },
   "2623": {
-    "codec": "O3EInt16",
+    "codec": "O3EComplexType",
     "len": 9,
     "id": "SeasonalEnergyEfficiencyRatioCooling",
     "args": {
-      "scale": 10.0,
-      "signed": false,
-      "offset": 0
+      "subTypes": [
+        {
+          "codec": "O3EInt8",
+          "len": 1,
+          "id": "CurrentYear",
+          "args": {
+            "scale": 10,
+            "signed": false,
+            "offset": 0
+          }
+        },
+        {
+          "codec": "O3EInt32",
+          "len": 4,
+          "id": "EnergyThermal",
+          "args": {
+            "scale": 10,
+            "signed": false,
+            "offset": 0
+          }
+        },
+        {
+          "codec": "O3EInt32",
+          "len": 4,
+          "id": "EnergyElectric",
+          "args": {
+            "scale": 10,
+            "signed": false,
+            "offset": 0
+          }
+        }
+      ]
     }
   },
   "2624": {
-    "codec": "O3EInt16",
+    "codec": "O3EComplexType",
     "len": 9,
-    "id": "SeasonalCoefficientOfPerformaceDomesticHotWater",
+    "id": "SeasonalCoefficientOfPerformanceDomesticHotWater",
     "args": {
-      "scale": 10.0,
-      "signed": false,
-      "offset": 0
+      "subTypes": [
+        {
+          "codec": "O3EInt8",
+          "len": 1,
+          "id": "CurrentYear",
+          "args": {
+            "scale": 10,
+            "signed": false,
+            "offset": 0
+          }
+        },
+        {
+          "codec": "O3EInt32",
+          "len": 4,
+          "id": "EnergyThermal",
+          "args": {
+            "scale": 10,
+            "signed": false,
+            "offset": 0
+          }
+        },
+        {
+          "codec": "O3EInt32",
+          "len": 4,
+          "id": "EnergyElectric",
+          "args": {
+            "scale": 10,
+            "signed": false,
+            "offset": 0
+          }
+        }
+      ]
     }
   },
   "2625": {
-    "codec": "O3EInt16",
+    "codec": "O3EComplexType",
     "len": 9,
-    "id": "SeasonalCoefficientOfPerformaceHeatingAndDomesticHotWater",
+    "id": "SeasonalCoefficientOfPerformanceHeatingAndDomesticHotWater",
     "args": {
-      "scale": 10.0,
-      "signed": false,
-      "offset": 0
+      "subTypes": [
+        {
+          "codec": "O3EInt8",
+          "len": 1,
+          "id": "CurrentYear",
+          "args": {
+            "scale": 10,
+            "signed": false,
+            "offset": 0
+          }
+        },
+        {
+          "codec": "O3EInt32",
+          "len": 4,
+          "id": "EnergyThermal",
+          "args": {
+            "scale": 10,
+            "signed": false,
+            "offset": 0
+          }
+        },
+        {
+          "codec": "O3EInt32",
+          "len": 4,
+          "id": "EnergyElectric",
+          "args": {
+            "scale": 10,
+            "signed": false,
+            "offset": 0
+          }
+        }
+      ]
     }
   },
   "2626": {
@@ -34368,5 +34484,5 @@
       ]
     }
   },
-  "Version": "20241125"
+  "Version": "20241203"
 }

--- a/src/open3e/Open3Edatapoints.py
+++ b/src/open3e/Open3Edatapoints.py
@@ -1426,10 +1426,10 @@ dataIdentifiers = {
         2612 : O3EComplexType(7, "PrimarySourceCommonSettingsHeating", [O3EByteVal(1, "Mode"), O3EInt16(2, "MaxFanSpeed"), O3EInt16(2, "DefaultFanSpeed"), O3EInt16(2, "MinFanSpeed")]),# ODU-FanSpeed --> Mode: Fixed/Variable, Unit: %
         2613 : O3EComplexType(7, "PrimarySourceCommonSettingsCooling", [O3EByteVal(1, "Mode"), O3EInt16(2, "MaxFanSpeed"), O3EInt16(2, "DefaultFanSpeed"), O3EInt16(2, "MinFanSpeed")]),# ODU-FanSpeed --> Mode: Fixed/Variable, Unit: %
         2621 : O3EInt16(2, "MaximumOperatingPressureActualTemperatureSetpoint"),
-        2622 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceHeating", [O3EInt8(1, "CurrentYear", scale=10), RawCodec(8, "Unknown")]), #250-xH
-        2623 : O3EComplexType(9, "SeasonalEnergyEfficiencyRatioCooling", [O3EInt8(1, "CurrentYear", scale=10), RawCodec(8, "Unknown")]), #250-xH
-        2624 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceDomesticHotWater", [O3EInt8(1, "CurrentYear", scale=10), RawCodec(8, "Unknown")]), #250-xH
-        2625 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceHeatingAndDomesticHotWater", [O3EInt8(1, "CurrentYear", scale=10), RawCodec(8, "Unknown")]), #250-xH
+        2622 : O3EComplexType(9, "SeasonalCoefficientOfPerformanceHeating", [O3EInt8(1, "CurrentYear", scale=10), O3EInt32(4, "EnergyThermal", scale=10), O3EInt32(4, "EnergyElectric", scale=10)]), #250-xH
+        2623 : O3EComplexType(9, "SeasonalEnergyEfficiencyRatioCooling", [O3EInt8(1, "CurrentYear", scale=10), O3EInt32(4, "EnergyThermal", scale=10), O3EInt32(4, "EnergyElectric", scale=10)]), #250-xH
+        2624 : O3EComplexType(9, "SeasonalCoefficientOfPerformanceDomesticHotWater", [O3EInt8(1, "CurrentYear", scale=10), O3EInt32(4, "EnergyThermal", scale=10), O3EInt32(4, "EnergyElectric", scale=10)]), #250-xH
+        2625 : O3EComplexType(9, "SeasonalCoefficientOfPerformanceHeatingAndDomesticHotWater", [O3EInt8(1, "CurrentYear", scale=10), O3EInt32(4, "EnergyThermal", scale=10), O3EInt32(4, "EnergyElectric", scale=10)]), #250-xH
         2626 : O3EInt32(4, "MaximumPowerElectricalHeater", scale = 1),
         2627 : O3EInt16(2, "CompressorStartUpTimer"),
         2629 : O3EInt32(4, "DesiredThermalCapacity", scale = 1),

--- a/src/open3e/Open3Edatapoints.py
+++ b/src/open3e/Open3Edatapoints.py
@@ -1426,10 +1426,10 @@ dataIdentifiers = {
         2612 : O3EComplexType(7, "PrimarySourceCommonSettingsHeating", [O3EByteVal(1, "Mode"), O3EInt16(2, "MaxFanSpeed"), O3EInt16(2, "DefaultFanSpeed"), O3EInt16(2, "MinFanSpeed")]),# ODU-FanSpeed --> Mode: Fixed/Variable, Unit: %
         2613 : O3EComplexType(7, "PrimarySourceCommonSettingsCooling", [O3EByteVal(1, "Mode"), O3EInt16(2, "MaxFanSpeed"), O3EInt16(2, "DefaultFanSpeed"), O3EInt16(2, "MinFanSpeed")]),# ODU-FanSpeed --> Mode: Fixed/Variable, Unit: %
         2621 : O3EInt16(2, "MaximumOperatingPressureActualTemperatureSetpoint"),
-        2622 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceHeating", [O3EInt8(2, "CurrentYear", scale=10), RawCodec(7, "Unknown")]), #250-xH
-        2623 : O3EComplexType(9, "SeasonalEnergyEfficiencyRatioCooling", [O3EInt8(2, "CurrentYear", scale=10), RawCodec(7, "Unknown")]), #250-xH
-        2624 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceDomesticHotWater", [O3EInt8(2, "CurrentYear", scale=10), RawCodec(7, "Unknown")]), #250-xH
-        2625 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceHeatingAndDomesticHotWater", [O3EInt8(2, "CurrentYear", scale=10), RawCodec(7, "Unknown")]), #250-xH
+        2622 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceHeating", [O3EInt8(1, "CurrentYear", scale=10), RawCodec(8, "Unknown")]), #250-xH
+        2623 : O3EComplexType(9, "SeasonalEnergyEfficiencyRatioCooling", [O3EInt8(1, "CurrentYear", scale=10), RawCodec(8, "Unknown")]), #250-xH
+        2624 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceDomesticHotWater", [O3EInt8(1, "CurrentYear", scale=10), RawCodec(8, "Unknown")]), #250-xH
+        2625 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceHeatingAndDomesticHotWater", [O3EInt8(1, "CurrentYear", scale=10), RawCodec(8, "Unknown")]), #250-xH
         2626 : O3EInt32(4, "MaximumPowerElectricalHeater", scale = 1),
         2627 : O3EInt16(2, "CompressorStartUpTimer"),
         2629 : O3EInt32(4, "DesiredThermalCapacity", scale = 1),

--- a/src/open3e/Open3Edatapoints.py
+++ b/src/open3e/Open3Edatapoints.py
@@ -1426,10 +1426,10 @@ dataIdentifiers = {
         2612 : O3EComplexType(7, "PrimarySourceCommonSettingsHeating", [O3EByteVal(1, "Mode"), O3EInt16(2, "MaxFanSpeed"), O3EInt16(2, "DefaultFanSpeed"), O3EInt16(2, "MinFanSpeed")]),# ODU-FanSpeed --> Mode: Fixed/Variable, Unit: %
         2613 : O3EComplexType(7, "PrimarySourceCommonSettingsCooling", [O3EByteVal(1, "Mode"), O3EInt16(2, "MaxFanSpeed"), O3EInt16(2, "DefaultFanSpeed"), O3EInt16(2, "MinFanSpeed")]),# ODU-FanSpeed --> Mode: Fixed/Variable, Unit: %
         2621 : O3EInt16(2, "MaximumOperatingPressureActualTemperatureSetpoint"),
-        2622 : O3EInt16(9, "SeasonalCoefficientOfPerformaceHeating"),
-        2623 : O3EInt16(9, "SeasonalEnergyEfficiencyRatioCooling"),
-        2624 : O3EInt16(9, "SeasonalCoefficientOfPerformaceDomesticHotWater"),
-        2625 : O3EInt16(9, "SeasonalCoefficientOfPerformaceHeatingAndDomesticHotWater"),
+        2622 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceHeating", [O3EInt8(2, "CurrentYear", scale=10), O3EByteVal(7, "Unknown")]), #250-xH
+        2623 : O3EComplexType(9, "SeasonalEnergyEfficiencyRatioCooling", [O3EInt8(2, "CurrentYear", scale=10), O3EByteVal(7, "Unknown")]), #250-xH
+        2624 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceDomesticHotWater", [O3EInt8(2, "CurrentYear", scale=10), O3EByteVal(7, "Unknown")]), #250-xH
+        2625 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceHeatingAndDomesticHotWater", [O3EInt8(2, "CurrentYear", scale=10), O3EByteVal(7, "Unknown")]), #250-xH
         2626 : O3EInt32(4, "MaximumPowerElectricalHeater", scale = 1),
         2627 : O3EInt16(2, "CompressorStartUpTimer"),
         2629 : O3EInt32(4, "DesiredThermalCapacity", scale = 1),

--- a/src/open3e/Open3Edatapoints.py
+++ b/src/open3e/Open3Edatapoints.py
@@ -1426,10 +1426,10 @@ dataIdentifiers = {
         2612 : O3EComplexType(7, "PrimarySourceCommonSettingsHeating", [O3EByteVal(1, "Mode"), O3EInt16(2, "MaxFanSpeed"), O3EInt16(2, "DefaultFanSpeed"), O3EInt16(2, "MinFanSpeed")]),# ODU-FanSpeed --> Mode: Fixed/Variable, Unit: %
         2613 : O3EComplexType(7, "PrimarySourceCommonSettingsCooling", [O3EByteVal(1, "Mode"), O3EInt16(2, "MaxFanSpeed"), O3EInt16(2, "DefaultFanSpeed"), O3EInt16(2, "MinFanSpeed")]),# ODU-FanSpeed --> Mode: Fixed/Variable, Unit: %
         2621 : O3EInt16(2, "MaximumOperatingPressureActualTemperatureSetpoint"),
-        2622 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceHeating", [O3EInt8(2, "CurrentYear", scale=10), O3EByteVal(7, "Unknown")]), #250-xH
-        2623 : O3EComplexType(9, "SeasonalEnergyEfficiencyRatioCooling", [O3EInt8(2, "CurrentYear", scale=10), O3EByteVal(7, "Unknown")]), #250-xH
-        2624 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceDomesticHotWater", [O3EInt8(2, "CurrentYear", scale=10), O3EByteVal(7, "Unknown")]), #250-xH
-        2625 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceHeatingAndDomesticHotWater", [O3EInt8(2, "CurrentYear", scale=10), O3EByteVal(7, "Unknown")]), #250-xH
+        2622 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceHeating", [O3EInt8(2, "CurrentYear", scale=10), RawCodec(7, "Unknown")]), #250-xH
+        2623 : O3EComplexType(9, "SeasonalEnergyEfficiencyRatioCooling", [O3EInt8(2, "CurrentYear", scale=10), RawCodec(7, "Unknown")]), #250-xH
+        2624 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceDomesticHotWater", [O3EInt8(2, "CurrentYear", scale=10), RawCodec(7, "Unknown")]), #250-xH
+        2625 : O3EComplexType(9, "SeasonalCoefficientOfPerformaceHeatingAndDomesticHotWater", [O3EInt8(2, "CurrentYear", scale=10), RawCodec(7, "Unknown")]), #250-xH
         2626 : O3EInt32(4, "MaximumPowerElectricalHeater", scale = 1),
         2627 : O3EInt16(2, "CompressorStartUpTimer"),
         2629 : O3EInt32(4, "DesiredThermalCapacity", scale = 1),


### PR DESCRIPTION
README: `-dev` option marked as deprecated, removed from examples and replaced by `-cnfg devices.json` / `-cnfg dev`; some other minors. 

datapoints: some codecs updated
