### PR TITLE
add version information to help output.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ __pycache__/
 .venv/
 dist/*
 build/*
+_scm_version.py
 #testing
 .coverage
 .DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,11 @@ where = ["src"]
 # exclude = ["tests"]
 namespaces = true
 
-# disable automatic versioning
-#[tool.setuptools_scm]
-#write_to = "src/tinypkg/_version.py"
+[tool.setuptools_scm]
+# write a version file at build time that contains the git ref, so that the ref is availble in the package code.
+version_file = "src/open3e/_scm_version.py"
+# override version file template, so that it contains the plain git ref, instead of the automatic generated version.
+version_file_template = 'git_ref = "{scm_version.node}"'
 
 # PEP 621 https://peps.python.org/pep-0621/
 [project]

--- a/src/open3e/Open3Eclient.py
+++ b/src/open3e/Open3Eclient.py
@@ -364,11 +364,30 @@ def main():
             print(f"{s}: {ecu}.{did} = {val}")
         else:
             print(f"{s}: {ecu}.{did}.{sub} = {val}")
-        
+
+    def get_package_version_string():
+        package_name = "open3e"
+
+        try:
+            from importlib.metadata import version
+            package_version = version(package_name)
+        except ImportError:
+            package_version = "unknown"
+
+        try:
+            from open3e import _scm_version as scm_version
+            git_ref = scm_version.git_ref
+        except ImportError:
+            git_ref = "unknown"
+
+        return f'{package_version} ({git_ref})'
+
     #~~~~~~~~~~~~~~~~~~~~~~
     # Main
     #~~~~~~~~~~~~~~~~~~~~~~
-    parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
+    help_version_string = get_package_version_string()
+
+    parser = argparse.ArgumentParser(fromfile_prefix_chars='@', epilog=f'open3e {help_version_string}')
     parser.add_argument("-c", "--can", type=str, help="use can device, e.g. can0")
     parser.add_argument("-d", "--doip", type=str, help="use doip access, e.g. 192.168.1.1")
     parser.add_argument("-dev", "--dev", type=str, help="boiler type --dev vdens or --dev vcal || pv/battery --dev vx3")


### PR DESCRIPTION
Adds version information (project version, git ref) to the open3e help text (via [epilog](https://docs.python.org/3/library/argparse.html#epilog)).

See also discussion in: https://github.com/open3e/open3e/discussions/197#discussioncomment-12107603

**Example**
```
(.venv) lgraf:open3e-dev-env/ $ open3e --help                                                                                                                  [18:06:52]
usage: open3e [-h] [-c CAN] [-d DOIP] [-dev DEV] [-tx ECUADDR] [-cnfg CONFIG] [-a] [-r READ] [-w WRITE] [-f77] [-raw] [-t TIMESTEP] [-l LISTEN] [-m MQTT]
              [-mfstr MQTTFORMATSTRING] [-muser MQTTUSER] [-mcid MQTTCLIENTID] [-j] [-v]

options:
  -h, --help            show this help message and exit
  -c, --can CAN         use can device, e.g. can0

...

open3e 0.5.1 (g612056a)
```